### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,6 +66,8 @@ jobs:
 
   apply:
     name: Apply Terraform Changes
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: [terraform, approve]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'


### PR DESCRIPTION
Potential fix for [https://github.com/vyas0189/powerwall/security/code-scanning/6](https://github.com/vyas0189/powerwall/security/code-scanning/6)

To fix the problem, add an explicit `permissions` block to the `apply` job in `.github/workflows/deploy.yml`. This block should grant only the minimal permissions required for the job to function. Since the job does not appear to interact with the repository (e.g., creating PRs, pushing code, etc.), the minimal permission of `contents: read` is appropriate. This change should be made directly under the `apply:` job definition, before the `runs-on` key.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
