### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/vyas0189/powerwall/security/code-scanning/1](https://github.com/vyas0189/powerwall/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file. The best way is to set the permissions at the workflow root level, so all jobs inherit the least privilege unless they need more. For this workflow, none of the jobs require write access to repository contents, issues, or pull requests. Therefore, the minimal permissions should be set to `contents: read`. This change should be made at the top level of the workflow, just below the `name:` and before the `on:` block. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
