### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,6 +55,7 @@ jobs:
 
   approve:
     name: Manual Approval
+    permissions: {}
     runs-on: ubuntu-latest
     needs: terraform
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'


### PR DESCRIPTION
Potential fix for [https://github.com/vyas0189/powerwall/security/code-scanning/5](https://github.com/vyas0189/powerwall/security/code-scanning/5)

To fix the problem, add an explicit `permissions: {}` block to the `approve` job in `.github/workflows/deploy.yml`. This ensures that the job does not have any permissions granted to the GITHUB_TOKEN, adhering to the principle of least privilege. The change should be made directly under the `name: Manual Approval` line (line 57), before `runs-on`. No other changes are required, and this will not affect the existing functionality of the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
