### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,8 @@ env:
 jobs:
   terraform:
     name: terraform
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     
     defaults:


### PR DESCRIPTION
Potential fix for [https://github.com/vyas0189/powerwall/security/code-scanning/2](https://github.com/vyas0189/powerwall/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block to the `terraform` job, specifying the minimum required permissions. Since the job only checks out code and does not need to write to the repository, `contents: read` is sufficient. This change should be made by adding the following lines under the `terraform` job definition (after `name: terraform` and before `runs-on: ubuntu-latest`). No additional imports or definitions are needed, as this is a YAML configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
