### PR TITLE
Add failure alerting and retry for NetZero API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,32 @@ The system automatically handles DST transitions using multiple EventBridge rule
 
 This ensures your Tesla system is configured at exactly 6:45 AM and 9:15 PM Houston local time throughout the year, regardless of daylight saving time changes. During DST transition weeks, the job may run twice, but only the correct local time execution will apply the configuration.
 
+## Reliability & Alerting
+
+### Retry
+
+Failures of the NetZero API call are retried at two layers:
+
+- **In-code retry**: each Lambda retries the API request up to 3 times with
+  exponential backoff (2s, 4s) to ride out transient errors within a single run.
+- **Scheduler retry**: if the Lambda invocation still fails, EventBridge
+  Scheduler retries the invocation (up to 2 attempts, within a 1-hour window).
+
+Runs that exhaust all retries are sent to an SQS **dead-letter queue**
+(`netzero-scheduler-dlq`, 14-day retention) for inspection or replay.
+
+### Failure alerts
+
+A CloudWatch alarm on each Lambda's `Errors` metric publishes to the
+`netzero-alerts` SNS topic, which emails `var.alert_email` (defaults to the
+project owner). You also receive a recovery ("OK") notification when the next
+run succeeds.
+
+> **One-time setup:** After the first deploy, AWS sends a subscription
+> confirmation email to the alert address. **You must click the confirmation
+> link** before any alerts are delivered. Override the address with
+> `-var="alert_email=you@example.com"`.
+
 ## Monitoring
 
 View logs in AWS CloudWatch:

--- a/evening_config.py
+++ b/evening_config.py
@@ -1,11 +1,38 @@
 import json
 import os
+import time
 import requests
 import logging
 from datetime import datetime
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
+
+# Retry configuration for transient NetZero API failures
+MAX_RETRIES = 3
+BACKOFF_BASE_SECONDS = 2
+REQUEST_TIMEOUT_SECONDS = 15
+
+
+def post_with_retry(url, config, headers):
+    """POST the config to the NetZero API, retrying transient failures with
+    exponential backoff. Raises the last RequestException if all attempts fail."""
+    last_exception = None
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            response = requests.post(
+                url, json=config, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS
+            )
+            response.raise_for_status()
+            return response
+        except requests.exceptions.RequestException as e:
+            last_exception = e
+            logger.warning(f"Attempt {attempt}/{MAX_RETRIES} failed: {str(e)}")
+            if attempt < MAX_RETRIES:
+                sleep_seconds = BACKOFF_BASE_SECONDS**attempt
+                logger.info(f"Retrying in {sleep_seconds}s")
+                time.sleep(sleep_seconds)
+    raise last_exception
 
 
 def lambda_handler(event, context):
@@ -35,8 +62,7 @@ def lambda_handler(event, context):
 
     try:
         logger.info(f"Applying evening configuration: {config}")
-        response = requests.post(url, json=config, headers=headers, timeout=30)
-        response.raise_for_status()
+        post_with_retry(url, config, headers)
 
         logger.info("Evening configuration applied successfully")
 
@@ -51,10 +77,11 @@ def lambda_handler(event, context):
         }
 
     except requests.exceptions.RequestException as e:
-        logger.error(f"Failed to apply evening configuration: {str(e)}")
-        return {
-            "statusCode": 500,
-            "body": json.dumps(
-                {"error": f"Failed to apply evening configuration: {str(e)}"}
-            ),
-        }
+        # Re-raise so the Lambda invocation is marked as failed. This increments
+        # the Lambda Errors metric (which triggers the CloudWatch alarm / SNS
+        # alert) and signals EventBridge Scheduler to retry and, on exhaustion,
+        # send the event to the dead-letter queue.
+        logger.error(
+            f"Failed to apply evening configuration after {MAX_RETRIES} attempts: {str(e)}"
+        )
+        raise

--- a/morning_config.py
+++ b/morning_config.py
@@ -1,11 +1,38 @@
 import json
 import os
+import time
 import requests
 import logging
 from datetime import datetime
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
+
+# Retry configuration for transient NetZero API failures
+MAX_RETRIES = 3
+BACKOFF_BASE_SECONDS = 2
+REQUEST_TIMEOUT_SECONDS = 15
+
+
+def post_with_retry(url, config, headers):
+    """POST the config to the NetZero API, retrying transient failures with
+    exponential backoff. Raises the last RequestException if all attempts fail."""
+    last_exception = None
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            response = requests.post(
+                url, json=config, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS
+            )
+            response.raise_for_status()
+            return response
+        except requests.exceptions.RequestException as e:
+            last_exception = e
+            logger.warning(f"Attempt {attempt}/{MAX_RETRIES} failed: {str(e)}")
+            if attempt < MAX_RETRIES:
+                sleep_seconds = BACKOFF_BASE_SECONDS**attempt
+                logger.info(f"Retrying in {sleep_seconds}s")
+                time.sleep(sleep_seconds)
+    raise last_exception
 
 
 def lambda_handler(event, context):
@@ -35,8 +62,7 @@ def lambda_handler(event, context):
 
     try:
         logger.info(f"Applying morning configuration: {config}")
-        response = requests.post(url, json=config, headers=headers, timeout=30)
-        response.raise_for_status()
+        post_with_retry(url, config, headers)
 
         logger.info("Morning configuration applied successfully")
 
@@ -51,10 +77,11 @@ def lambda_handler(event, context):
         }
 
     except requests.exceptions.RequestException as e:
-        logger.error(f"Failed to apply morning configuration: {str(e)}")
-        return {
-            "statusCode": 500,
-            "body": json.dumps(
-                {"error": f"Failed to apply morning configuration: {str(e)}"}
-            ),
-        }
+        # Re-raise so the Lambda invocation is marked as failed. This increments
+        # the Lambda Errors metric (which triggers the CloudWatch alarm / SNS
+        # alert) and signals EventBridge Scheduler to retry and, on exhaustion,
+        # send the event to the dead-letter queue.
+        logger.error(
+            f"Failed to apply morning configuration after {MAX_RETRIES} attempts: {str(e)}"
+        )
+        raise

--- a/terraform/alerts.tf
+++ b/terraform/alerts.tf
@@ -1,0 +1,88 @@
+# SNS topic for failure alerts
+resource "aws_sns_topic" "alerts" {
+  name = "netzero-alerts"
+}
+
+# Email subscription. AWS sends a confirmation email to this address; the
+# subscription stays "pending confirmation" until the link in that email is
+# clicked. Alerts are only delivered after confirmation.
+resource "aws_sns_topic_subscription" "alerts_email" {
+  topic_arn = aws_sns_topic.alerts.arn
+  protocol  = "email"
+  endpoint  = var.alert_email
+}
+
+# Dead-letter queue for scheduler events whose Lambda invocations exhaust all
+# retries. Lets you inspect/replay runs that failed even after retrying.
+resource "aws_sqs_queue" "scheduler_dlq" {
+  name                      = "netzero-scheduler-dlq"
+  message_retention_seconds = 1209600 # 14 days (max)
+}
+
+# Allow EventBridge Scheduler (via the scheduler role) to send dead-letter
+# messages to the queue.
+resource "aws_sqs_queue_policy" "scheduler_dlq_policy" {
+  queue_url = aws_sqs_queue.scheduler_dlq.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "scheduler.amazonaws.com" }
+        Action    = "sqs:SendMessage"
+        Resource  = aws_sqs_queue.scheduler_dlq.arn
+        Condition = {
+          ArnEquals = {
+            "aws:SourceArn" = [
+              aws_scheduler_schedule.morning_schedule.arn,
+              aws_scheduler_schedule.evening_schedule.arn
+            ]
+          }
+        }
+      }
+    ]
+  })
+}
+
+# CloudWatch alarm on morning Lambda errors -> SNS email alert
+resource "aws_cloudwatch_metric_alarm" "morning_errors" {
+  alarm_name          = "netzero-morning-config-errors"
+  alarm_description   = "Morning Tesla config Lambda failed (after in-code retries)"
+  namespace           = "AWS/Lambda"
+  metric_name         = "Errors"
+  statistic           = "Sum"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = 1
+  period              = 300
+  evaluation_periods  = 1
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    FunctionName = aws_lambda_function.morning_config.function_name
+  }
+
+  alarm_actions = [aws_sns_topic.alerts.arn]
+  ok_actions    = [aws_sns_topic.alerts.arn]
+}
+
+# CloudWatch alarm on evening Lambda errors -> SNS email alert
+resource "aws_cloudwatch_metric_alarm" "evening_errors" {
+  alarm_name          = "netzero-evening-config-errors"
+  alarm_description   = "Evening Tesla config Lambda failed (after in-code retries)"
+  namespace           = "AWS/Lambda"
+  metric_name         = "Errors"
+  statistic           = "Sum"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = 1
+  period              = 300
+  evaluation_periods  = 1
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    FunctionName = aws_lambda_function.evening_config.function_name
+  }
+
+  alarm_actions = [aws_sns_topic.alerts.arn]
+  ok_actions    = [aws_sns_topic.alerts.arn]
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -32,6 +32,49 @@ resource "aws_iam_user_policy" "github_actions_policy" {
       {
         Effect = "Allow"
         Action = [
+          "sns:CreateTopic",
+          "sns:DeleteTopic",
+          "sns:GetTopicAttributes",
+          "sns:SetTopicAttributes",
+          "sns:Subscribe",
+          "sns:Unsubscribe",
+          "sns:ListSubscriptionsByTopic",
+          "sns:GetSubscriptionAttributes",
+          "sns:ListTagsForResource",
+          "sns:TagResource",
+          "sns:UntagResource"
+        ]
+        Resource = "arn:aws:sns:us-east-1:358870220937:netzero-*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "sqs:CreateQueue",
+          "sqs:DeleteQueue",
+          "sqs:GetQueueAttributes",
+          "sqs:SetQueueAttributes",
+          "sqs:GetQueueUrl",
+          "sqs:ListQueueTags",
+          "sqs:TagQueue",
+          "sqs:UntagQueue"
+        ]
+        Resource = "arn:aws:sqs:us-east-1:358870220937:netzero-*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "cloudwatch:PutMetricAlarm",
+          "cloudwatch:DeleteAlarms",
+          "cloudwatch:DescribeAlarms",
+          "cloudwatch:ListTagsForResource",
+          "cloudwatch:TagResource",
+          "cloudwatch:UntagResource"
+        ]
+        Resource = "arn:aws:cloudwatch:us-east-1:358870220937:alarm:netzero-*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
           "iam:GetRole",
           "iam:CreateRole",
           "iam:PassRole",
@@ -129,6 +172,11 @@ resource "aws_iam_role_policy" "scheduler_invoke_lambda" {
           aws_lambda_function.morning_config.arn,
           aws_lambda_function.evening_config.arn
         ]
+      },
+      {
+        Effect   = "Allow"
+        Action   = "sqs:SendMessage"
+        Resource = aws_sqs_queue.scheduler_dlq.arn
       }
     ]
   })

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -5,7 +5,7 @@ resource "aws_lambda_function" "morning_config" {
   role             = aws_iam_role.lambda_role.arn
   handler          = "morning_config.lambda_handler"
   runtime          = "python3.12"
-  timeout          = 30
+  timeout          = 60
   source_code_hash = base64sha256("${filemd5("${path.module}/../morning_config.py")}-${filemd5("${path.module}/../requirements.txt")}")
 
   environment {
@@ -25,7 +25,7 @@ resource "aws_lambda_function" "evening_config" {
   role             = aws_iam_role.lambda_role.arn
   handler          = "evening_config.lambda_handler"
   runtime          = "python3.12"
-  timeout          = 30
+  timeout          = 60
   source_code_hash = base64sha256("${filemd5("${path.module}/../evening_config.py")}-${filemd5("${path.module}/../requirements.txt")}")
 
   environment {

--- a/terraform/scheduler.tf
+++ b/terraform/scheduler.tf
@@ -13,6 +13,15 @@ resource "aws_scheduler_schedule" "morning_schedule" {
   target {
     arn      = aws_lambda_function.morning_config.arn
     role_arn = aws_iam_role.scheduler_role.arn
+
+    retry_policy {
+      maximum_retry_attempts       = 2
+      maximum_event_age_in_seconds = 3600
+    }
+
+    dead_letter_config {
+      arn = aws_sqs_queue.scheduler_dlq.arn
+    }
   }
 }
 
@@ -31,5 +40,14 @@ resource "aws_scheduler_schedule" "evening_schedule" {
   target {
     arn      = aws_lambda_function.evening_config.arn
     role_arn = aws_iam_role.scheduler_role.arn
+
+    retry_policy {
+      maximum_retry_attempts       = 2
+      maximum_event_age_in_seconds = 3600
+    }
+
+    dead_letter_config {
+      arn = aws_sqs_queue.scheduler_dlq.arn
+    }
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -14,3 +14,9 @@ variable "site_id" {
   description = "Tesla site ID"
   type        = string
 }
+
+variable "alert_email" {
+  description = "Email address that receives failure alerts for the Lambda jobs"
+  type        = string
+  default     = "vyas0189@gmail.com"
+}


### PR DESCRIPTION
## Summary

Previously a failed NetZero API call was logged and swallowed (the handler returned a `500` that nothing consumed), so **no alert fired and there was no retry** — a failed run silently left the Powerwall in the wrong mode until the next job. This PR adds retry and failure alerting.

Estimated added AWS cost at this volume (~120 invocations/month): **~$0/month** (everything sits in the always-free tier; worst case ~$0.20/month if the 10 free CloudWatch alarms are already used).

## Changes

**Retry — two layers**
- In-code exponential backoff (3 attempts, 2s/4s) in both Lambdas, re-raising on exhaustion so the invocation is marked failed.
- EventBridge Scheduler retry policy (2 attempts, 1-hour window) as a backstop.
- Exhausted runs go to an SQS **dead-letter queue** (`netzero-scheduler-dlq`, 14-day retention) for inspection/replay.

**Alerting**
- CloudWatch alarm on each Lambda's `Errors` metric → SNS topic `netzero-alerts` → email subscription (`var.alert_email`, defaults to project owner). Recovery ("OK") notifications included.

**Supporting changes**
- IAM: deploy user gets SNS/SQS/CloudWatch permissions; scheduler role gets `sqs:SendMessage` to the DLQ.
- Lambda timeout bumped 30s → 60s to cover retry backoff.
- README documents the setup.

## ⚠️ One-time manual step
After the first deploy, AWS emails a subscription confirmation to the alert address. **The link must be clicked** before any alerts are delivered. Override the address with `-var="alert_email=you@example.com"`.

## Testing
- `black --check` and `flake8` (E9,F63,F7,F82) pass on both Lambdas.
- `python -m py_compile` passes.
- `terraform fmt -check -recursive` clean. (`terraform validate` runs in CI — the provider registry is network-blocked in this environment.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019mgbdwt9SRP15mf1QaGLcG)_