### PR TITLE
Fix deploy: split IAM policy under inline 2048-byte limit

### DIFF
--- a/terraform/alerts.tf
+++ b/terraform/alerts.tf
@@ -1,6 +1,9 @@
 # SNS topic for failure alerts
 resource "aws_sns_topic" "alerts" {
   name = "netzero-alerts"
+
+  # Ensure the deploy user's SNS permissions exist before creating the topic
+  depends_on = [aws_iam_user_policy.github_actions_alerting_policy]
 }
 
 # Email subscription. AWS sends a confirmation email to this address; the
@@ -17,6 +20,9 @@ resource "aws_sns_topic_subscription" "alerts_email" {
 resource "aws_sqs_queue" "scheduler_dlq" {
   name                      = "netzero-scheduler-dlq"
   message_retention_seconds = 1209600 # 14 days (max)
+
+  # Ensure the deploy user's SQS permissions exist before creating the queue
+  depends_on = [aws_iam_user_policy.github_actions_alerting_policy]
 }
 
 # Allow EventBridge Scheduler (via the scheduler role) to send dead-letter
@@ -64,6 +70,8 @@ resource "aws_cloudwatch_metric_alarm" "morning_errors" {
 
   alarm_actions = [aws_sns_topic.alerts.arn]
   ok_actions    = [aws_sns_topic.alerts.arn]
+
+  depends_on = [aws_iam_user_policy.github_actions_alerting_policy]
 }
 
 # CloudWatch alarm on evening Lambda errors -> SNS email alert
@@ -85,4 +93,6 @@ resource "aws_cloudwatch_metric_alarm" "evening_errors" {
 
   alarm_actions = [aws_sns_topic.alerts.arn]
   ok_actions    = [aws_sns_topic.alerts.arn]
+
+  depends_on = [aws_iam_user_policy.github_actions_alerting_policy]
 }

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -32,6 +32,56 @@ resource "aws_iam_user_policy" "github_actions_policy" {
       {
         Effect = "Allow"
         Action = [
+          "iam:GetRole",
+          "iam:CreateRole",
+          "iam:PassRole",
+          "iam:AttachRolePolicy",
+          "iam:DetachRolePolicy",
+          "iam:ListRolePolicies",
+          "iam:ListAttachedRolePolicies",
+          "iam:GetRolePolicy",
+          "iam:PutRolePolicy",
+          "iam:DeleteRolePolicy"
+        ]
+        Resource = "arn:aws:iam::358870220937:role/netzero-*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["iam:GetUserPolicy", "iam:PutUserPolicy"]
+        Resource = "arn:aws:iam::358870220937:user/netzero-github-actions"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["logs:CreateLogGroup", "logs:DescribeLogGroups"]
+        Resource = "arn:aws:logs:us-east-1:358870220937:log-group:/aws/lambda/netzero-*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+        Resource = "arn:aws:s3:::netzero-terraform-state-358870220937/terraform.tfstate"
+      },
+      {
+        Effect   = "Allow"
+        Action   = "s3:ListBucket"
+        Resource = "arn:aws:s3:::netzero-terraform-state-358870220937"
+      }
+    ]
+  })
+}
+
+# Separate inline policy for alerting/retry infrastructure (SNS, SQS, CloudWatch).
+# Kept separate from GitHubActionsPolicy because a single inline user policy is
+# capped at 2048 bytes; each named inline policy gets its own budget.
+resource "aws_iam_user_policy" "github_actions_alerting_policy" {
+  name = "GitHubActionsAlertingPolicy"
+  user = "netzero-github-actions"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
           "sns:CreateTopic",
           "sns:DeleteTopic",
           "sns:GetTopicAttributes",
@@ -71,42 +121,6 @@ resource "aws_iam_user_policy" "github_actions_policy" {
           "cloudwatch:UntagResource"
         ]
         Resource = "arn:aws:cloudwatch:us-east-1:358870220937:alarm:netzero-*"
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "iam:GetRole",
-          "iam:CreateRole",
-          "iam:PassRole",
-          "iam:AttachRolePolicy",
-          "iam:DetachRolePolicy",
-          "iam:ListRolePolicies",
-          "iam:ListAttachedRolePolicies",
-          "iam:GetRolePolicy",
-          "iam:PutRolePolicy",
-          "iam:DeleteRolePolicy"
-        ]
-        Resource = "arn:aws:iam::358870220937:role/netzero-*"
-      },
-      {
-        Effect   = "Allow"
-        Action   = ["iam:GetUserPolicy", "iam:PutUserPolicy"]
-        Resource = "arn:aws:iam::358870220937:user/netzero-github-actions"
-      },
-      {
-        Effect   = "Allow"
-        Action   = ["logs:CreateLogGroup", "logs:DescribeLogGroups"]
-        Resource = "arn:aws:logs:us-east-1:358870220937:log-group:/aws/lambda/netzero-*"
-      },
-      {
-        Effect   = "Allow"
-        Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
-        Resource = "arn:aws:s3:::netzero-terraform-state-358870220937/terraform.tfstate"
-      },
-      {
-        Effect   = "Allow"
-        Action   = "s3:ListBucket"
-        Resource = "arn:aws:s3:::netzero-terraform-state-358870220937"
       }
     ]
   })


### PR DESCRIPTION
## Summary

The post-merge deploy of #44 failed at `terraform apply`. Root cause: adding the SNS/SQS/CloudWatch statements pushed the `GitHubActionsPolicy` **inline** user policy to **2303 bytes**, over AWS's **2048-byte hard limit** for inline user policies (`LimitExceeded`). Because that `PutUserPolicy` failed, the new permissions never attached — so creating the SNS topic and SQS queue then failed with `403 AccessDenied`.

(The Lambda timeout changes from #44 did apply; only the alerting resources failed.)

## Fix

- Move the alerting permissions into a **separate inline policy** `GitHubActionsAlertingPolicy`. Each named inline policy gets its own 2048-byte budget, so this keeps the explicit least-privilege actions **without broadening to wildcards**.
  - Reverted `GitHubActionsPolicy`: ~1456 bytes
  - New `GitHubActionsAlertingPolicy`: ~885 bytes
- Add `depends_on` from the SNS topic, SQS queue, and CloudWatch alarms to the new policy, so the deploy user's permissions exist before those resources are created (matches the existing `scheduler_role` ordering pattern).

## Testing
- `terraform fmt -check -recursive` clean.
- Policy sizes computed against minified JSON (how AWS measures): both well under 2048.
- `terraform validate` / `apply` run in CI + the deploy pipeline (provider registry is network-blocked in this dev environment).

## Note
This still requires approving the production gate on the deploy run, and confirming the SNS subscription email after it succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019mgbdwt9SRP15mf1QaGLcG)_