### PR TITLE
Fix deploy: fit IAM under aggregate 2048-byte inline cap via scoped wildcards

### DIFF
--- a/terraform/alerts.tf
+++ b/terraform/alerts.tf
@@ -3,7 +3,7 @@ resource "aws_sns_topic" "alerts" {
   name = "netzero-alerts"
 
   # Ensure the deploy user's SNS permissions exist before creating the topic
-  depends_on = [aws_iam_user_policy.github_actions_alerting_policy]
+  depends_on = [aws_iam_user_policy.github_actions_policy]
 }
 
 # Email subscription. AWS sends a confirmation email to this address; the
@@ -22,7 +22,7 @@ resource "aws_sqs_queue" "scheduler_dlq" {
   message_retention_seconds = 1209600 # 14 days (max)
 
   # Ensure the deploy user's SQS permissions exist before creating the queue
-  depends_on = [aws_iam_user_policy.github_actions_alerting_policy]
+  depends_on = [aws_iam_user_policy.github_actions_policy]
 }
 
 # Allow EventBridge Scheduler (via the scheduler role) to send dead-letter
@@ -71,7 +71,7 @@ resource "aws_cloudwatch_metric_alarm" "morning_errors" {
   alarm_actions = [aws_sns_topic.alerts.arn]
   ok_actions    = [aws_sns_topic.alerts.arn]
 
-  depends_on = [aws_iam_user_policy.github_actions_alerting_policy]
+  depends_on = [aws_iam_user_policy.github_actions_policy]
 }
 
 # CloudWatch alarm on evening Lambda errors -> SNS email alert
@@ -94,5 +94,5 @@ resource "aws_cloudwatch_metric_alarm" "evening_errors" {
   alarm_actions = [aws_sns_topic.alerts.arn]
   ok_actions    = [aws_sns_topic.alerts.arn]
 
-  depends_on = [aws_iam_user_policy.github_actions_alerting_policy]
+  depends_on = [aws_iam_user_policy.github_actions_policy]
 }

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -6,6 +6,10 @@ resource "aws_iam_user_policy" "github_actions_policy" {
   name = "GitHubActionsPolicy"
   user = "netzero-github-actions"
 
+  # NOTE: AWS caps the *aggregate* size of all inline policies on a user at 2048
+  # bytes, so this must remain a single inline policy. To keep the alerting
+  # resources (SNS/SQS/CloudWatch) within that budget their actions use
+  # service-level wildcards, tightly scoped to netzero-* ARNs.
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -28,6 +32,21 @@ resource "aws_iam_user_policy" "github_actions_policy" {
         Effect   = "Allow"
         Action   = ["scheduler:CreateSchedule", "scheduler:DeleteSchedule", "scheduler:GetSchedule", "scheduler:UpdateSchedule"]
         Resource = "arn:aws:scheduler:us-east-1:358870220937:schedule/default/netzero-*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = "sns:*"
+        Resource = "arn:aws:sns:us-east-1:358870220937:netzero-*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = "sqs:*"
+        Resource = "arn:aws:sqs:us-east-1:358870220937:netzero-*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = "cloudwatch:*"
+        Resource = "arn:aws:cloudwatch:us-east-1:358870220937:alarm:netzero-*"
       },
       {
         Effect = "Allow"
@@ -64,63 +83,6 @@ resource "aws_iam_user_policy" "github_actions_policy" {
         Effect   = "Allow"
         Action   = "s3:ListBucket"
         Resource = "arn:aws:s3:::netzero-terraform-state-358870220937"
-      }
-    ]
-  })
-}
-
-# Separate inline policy for alerting/retry infrastructure (SNS, SQS, CloudWatch).
-# Kept separate from GitHubActionsPolicy because a single inline user policy is
-# capped at 2048 bytes; each named inline policy gets its own budget.
-resource "aws_iam_user_policy" "github_actions_alerting_policy" {
-  name = "GitHubActionsAlertingPolicy"
-  user = "netzero-github-actions"
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "sns:CreateTopic",
-          "sns:DeleteTopic",
-          "sns:GetTopicAttributes",
-          "sns:SetTopicAttributes",
-          "sns:Subscribe",
-          "sns:Unsubscribe",
-          "sns:ListSubscriptionsByTopic",
-          "sns:GetSubscriptionAttributes",
-          "sns:ListTagsForResource",
-          "sns:TagResource",
-          "sns:UntagResource"
-        ]
-        Resource = "arn:aws:sns:us-east-1:358870220937:netzero-*"
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "sqs:CreateQueue",
-          "sqs:DeleteQueue",
-          "sqs:GetQueueAttributes",
-          "sqs:SetQueueAttributes",
-          "sqs:GetQueueUrl",
-          "sqs:ListQueueTags",
-          "sqs:TagQueue",
-          "sqs:UntagQueue"
-        ]
-        Resource = "arn:aws:sqs:us-east-1:358870220937:netzero-*"
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "cloudwatch:PutMetricAlarm",
-          "cloudwatch:DeleteAlarms",
-          "cloudwatch:DescribeAlarms",
-          "cloudwatch:ListTagsForResource",
-          "cloudwatch:TagResource",
-          "cloudwatch:UntagResource"
-        ]
-        Resource = "arn:aws:cloudwatch:us-east-1:358870220937:alarm:netzero-*"
       }
     ]
   })


### PR DESCRIPTION
## Summary

The deploy of #45 failed again — same `LimitExceeded: Maximum policy size of 2048 bytes exceeded`, this time on the new `GitHubActionsAlertingPolicy` (only 885 bytes on its own).

**Why the split couldn't work:** AWS's 2048-byte limit on inline user policies is an **aggregate cap across all of the user's inline policies**, not per-policy. So `1456 + 885 = 2341` was always going to exceed it. My previous "split into two policies" approach was based on a wrong reading of the limit.

## Fix (confirmed approach: scoped wildcards)

- Collapse back to a **single inline policy** and shrink it by giving the three alerting services service-level wildcards — `sns:*`, `sqs:*`, `cloudwatch:*` — each kept **tightly scoped to `netzero-*` ARNs**.
- Lambda, Scheduler, IAM, logs, and S3 statements stay **explicit/unchanged**.
- Final size: **1758 bytes** (290 under the 2048 cap).
- `depends_on` references repointed to the single policy.

### Security note
This is a deliberate, mild loosening of least-privilege for the alerting services only — actions are wildcarded but constrained to `netzero-*` resources in this account/region. The strict-explicit alternative requires moving to a customer-managed policy (6144-byte limit), which needs new `iam:CreatePolicy`/`AttachUserPolicy` grants and risks a two-phase apply / IAM-propagation failure — so we chose the lower-risk path.

## Testing
- `terraform fmt -check -recursive` clean.
- Policy size computed against minified JSON (how AWS measures): 1758 bytes.
- `terraform validate` / `apply` run in CI + the deploy pipeline.

Still requires approving the production gate, then confirming the SNS subscription email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019mgbdwt9SRP15mf1QaGLcG)_