### PR TITLE
Future-proof deploy against IAM propagation races with time_sleep

### DIFF
--- a/terraform/alerts.tf
+++ b/terraform/alerts.tf
@@ -1,9 +1,24 @@
+# Give IAM time to propagate the deploy user's SNS/SQS/CloudWatch grants before
+# any resource that needs them is created. Without this, a fresh apply can fire
+# CreateTopic/CreateQueue within ~1s of the policy update and get a 403 because
+# the grant hasn't propagated yet (IAM is eventually consistent).
+resource "time_sleep" "wait_for_iam_propagation" {
+  depends_on      = [aws_iam_user_policy.github_actions_policy]
+  create_duration = "30s"
+
+  # Re-wait whenever the policy document changes, so future permission additions
+  # get the same propagation grace period.
+  triggers = {
+    policy = aws_iam_user_policy.github_actions_policy.policy
+  }
+}
+
 # SNS topic for failure alerts
 resource "aws_sns_topic" "alerts" {
   name = "netzero-alerts"
 
-  # Ensure the deploy user's SNS permissions exist before creating the topic
-  depends_on = [aws_iam_user_policy.github_actions_policy]
+  # Wait for the deploy user's SNS permissions to propagate before creating
+  depends_on = [time_sleep.wait_for_iam_propagation]
 }
 
 # Email subscription. AWS sends a confirmation email to this address; the
@@ -21,8 +36,8 @@ resource "aws_sqs_queue" "scheduler_dlq" {
   name                      = "netzero-scheduler-dlq"
   message_retention_seconds = 1209600 # 14 days (max)
 
-  # Ensure the deploy user's SQS permissions exist before creating the queue
-  depends_on = [aws_iam_user_policy.github_actions_policy]
+  # Wait for the deploy user's SQS permissions to propagate before creating
+  depends_on = [time_sleep.wait_for_iam_propagation]
 }
 
 # Allow EventBridge Scheduler (via the scheduler role) to send dead-letter
@@ -71,7 +86,7 @@ resource "aws_cloudwatch_metric_alarm" "morning_errors" {
   alarm_actions = [aws_sns_topic.alerts.arn]
   ok_actions    = [aws_sns_topic.alerts.arn]
 
-  depends_on = [aws_iam_user_policy.github_actions_policy]
+  depends_on = [time_sleep.wait_for_iam_propagation]
 }
 
 # CloudWatch alarm on evening Lambda errors -> SNS email alert
@@ -94,5 +109,5 @@ resource "aws_cloudwatch_metric_alarm" "evening_errors" {
   alarm_actions = [aws_sns_topic.alerts.arn]
   ok_actions    = [aws_sns_topic.alerts.arn]
 
-  depends_on = [aws_iam_user_policy.github_actions_policy]
+  depends_on = [time_sleep.wait_for_iam_propagation]
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,6 +4,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 6.9"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.12"
+    }
   }
 
   backend "s3" {


### PR DESCRIPTION
## Summary

Future-proofs the deploy against the IAM eventual-consistency race that forced a manual re-run during the alerting rollout.

**The problem:** on a fresh apply (or any future permission change), Terraform fires the SNS/SQS/CloudWatch create calls within ~1s of updating the deploy user's IAM policy — before AWS propagates the new grant — yielding `403 AccessDenied`. `depends_on` enforced ordering but can't cover IAM's propagation lag.

**The fix:**
- Add `time_sleep.wait_for_iam_propagation` (hashicorp/time provider) that waits **30s** after the IAM policy is updated.
- Repoint the SNS topic, SQS queue, and both CloudWatch alarms to depend on the sleep instead of directly on the policy.
- A `triggers` on the policy document re-arms the wait whenever permissions change, so future grants get the same grace period (and steady-state applies, where the policy is unchanged, don't re-wait).

## Notes
- `time` provider added to `required_providers` (`~> 0.12`). No lock file is committed and the deploy runs plain `terraform init`, so it's fetched automatically.
- `terraform fmt -check -recursive` clean.
- No change to runtime behavior of the Lambdas, alarms, or retry/DLQ — this only affects apply-time ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019mgbdwt9SRP15mf1QaGLcG)_