### PR TITLE
Recover half-applied IAM migration (temporary -refresh=false)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,8 +78,13 @@ jobs:
       run: terraform validate
     
     - name: Terraform Plan
+      # TEMPORARY: -refresh=false to recover from the half-applied IAM migration
+      # (operational perms were stripped from the inline policy before the managed
+      # policy was attached, so refresh can't read SNS/SQS). Remove once the deploy
+      # has healed and the netzero-deploy managed policy is attached.
       run: |
         terraform plan \
+          -refresh=false \
           -var="api_key=${{ secrets.API_KEY }}" \
           -var="site_id=${{ secrets.SITE_ID }}" \
           -out=tfplan
@@ -129,8 +134,11 @@ jobs:
       run: terraform init
     
     - name: Terraform Plan (Fresh)
+      # TEMPORARY: -refresh=false to recover from the half-applied IAM migration
+      # (see note in the Terraform Plan step above). Remove once healed.
       run: |
         terraform plan \
+          -refresh=false \
           -var="api_key=${{ secrets.API_KEY }}" \
           -var="site_id=${{ secrets.SITE_ID }}" \
           -out=fresh-tfplan


### PR DESCRIPTION
## Why

PR #48's hardening **half-applied**: the deploy run modified the inline policy to remove the operational SNS/SQS/CloudWatch/Lambda permissions (which were supposed to move to the managed policy) **before** the `netzero-deploy` managed policy could be created/attached — `iam:CreatePolicy` hadn't propagated yet (and a re-run hit the same race).

Result: the deploy user now has **neither** the inline operational perms nor the managed policy. `terraform plan` fails during **refresh** (can't read the existing SNS topic / SQS queue), which blocks the very apply that would restore those perms. The pipeline can't self-heal through a normal re-run.

## Fix

Add `-refresh=false` to both deploy plan steps (pre-gate `terraform` job and the `apply` job's fresh plan). This lets plan/apply proceed from state without the failing reads, so the apply can **create + attach the `netzero-deploy` managed policy**, restoring the operational permissions via the explicit (no-wildcard) actions.

This works because the inline policy deliberately retained `PutUserPolicy` / `CreatePolicy` / `AttachUserPolicy` — exactly the recovery path designed into #48.

## Plan that will run (from state)
`3 to add`: `aws_iam_policy.deploy`, `aws_iam_user_policy_attachment.deploy`, `time_sleep.wait_for_iam_propagation`. No changes to existing resources.

## ⚠️ Temporary
The `-refresh=false` flag is a recovery measure only. Once this deploy succeeds (managed policy attached, perms restored), I'll open a **follow-up to remove it** so drift detection is back on. After that, refresh works normally because the managed policy grants the read permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019mgbdwt9SRP15mf1QaGLcG)_