### PR TITLE
Remove temporary -refresh=false from deploy (migration healed)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,13 +78,8 @@ jobs:
       run: terraform validate
     
     - name: Terraform Plan
-      # TEMPORARY: -refresh=false to recover from the half-applied IAM migration
-      # (operational perms were stripped from the inline policy before the managed
-      # policy was attached, so refresh can't read SNS/SQS). Remove once the deploy
-      # has healed and the netzero-deploy managed policy is attached.
       run: |
         terraform plan \
-          -refresh=false \
           -var="api_key=${{ secrets.API_KEY }}" \
           -var="site_id=${{ secrets.SITE_ID }}" \
           -out=tfplan
@@ -134,11 +129,8 @@ jobs:
       run: terraform init
     
     - name: Terraform Plan (Fresh)
-      # TEMPORARY: -refresh=false to recover from the half-applied IAM migration
-      # (see note in the Terraform Plan step above). Remove once healed.
       run: |
         terraform plan \
-          -refresh=false \
           -var="api_key=${{ secrets.API_KEY }}" \
           -var="site_id=${{ secrets.SITE_ID }}" \
           -out=fresh-tfplan


### PR DESCRIPTION
## Summary

Follow-up cleanup to #49. The half-applied IAM migration has healed — deploy run [28006715351](https://github.com/vyas0189/powerwall/actions/runs/28006715351) succeeded, creating and attaching the `netzero-deploy` managed policy, so the deploy user once again has the operational permissions and `terraform plan` can refresh normally.

This removes the temporary `-refresh=false` flag from both deploy plan steps, restoring drift detection.

## Verification
- The prior deploy's Apply job completed successfully (managed policy + attachment + propagation wait created).
- With the managed policy attached, refresh reads (SNS `GetTopicAttributes`, SQS `GetQueueAttributes`, etc.) are now permitted, so a normal refreshing plan works again.

## Net result of the whole effort
Operational IAM is now **explicit and scoped to `netzero-*`** in a customer-managed policy — the `sns:*`/`sqs:*`/`cloudwatch:*` wildcards are gone — with the inline policy reduced to a control plane that can't self-escalate (attach restricted to `netzero-*` policies via an `iam:PolicyARN` condition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019mgbdwt9SRP15mf1QaGLcG)_