### PR TITLE
Move NetZero API key to SSM SecureString (out of env var and state)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,6 @@ jobs:
           echo "✅ AWS_SECRET_ACCESS_KEY is set"
         fi
         
-        if [ -z "${{ secrets.API_KEY }}" ]; then
-          echo "❌ API_KEY secret is missing"
-          exit 1
-        else
-          echo "✅ API_KEY is set"
-        fi
-        
         if [ -z "${{ secrets.SITE_ID }}" ]; then
           echo "❌ SITE_ID secret is missing"
           exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,7 +80,6 @@ jobs:
     - name: Terraform Plan
       run: |
         terraform plan \
-          -var="api_key=${{ secrets.API_KEY }}" \
           -var="site_id=${{ secrets.SITE_ID }}" \
           -out=tfplan
     
@@ -131,7 +130,6 @@ jobs:
     - name: Terraform Plan (Fresh)
       run: |
         terraform plan \
-          -var="api_key=${{ secrets.API_KEY }}" \
           -var="site_id=${{ secrets.SITE_ID }}" \
           -out=fresh-tfplan
     

--- a/README.md
+++ b/README.md
@@ -41,9 +41,30 @@ cd netzero-api
 Go to your repository's Settings → Secrets and variables → Actions, and add:
 
 - `AWS_ACCESS_KEY_ID` - Your AWS access key
-- `AWS_SECRET_ACCESS_KEY` - Your AWS secret key  
-- `API_KEY` - Your NetZero API key
+- `AWS_SECRET_ACCESS_KEY` - Your AWS secret key
 - `SITE_ID` - Your Tesla site ID
+
+> The NetZero API key is **not** a GitHub secret. It lives in an SSM Parameter
+> Store SecureString that the Lambdas read at runtime, so it never enters the
+> Lambda env config or Terraform state (see below). The old `API_KEY` GitHub
+> secret can be removed.
+
+### Store the NetZero API key (one-time)
+
+Create the SSM SecureString **before** the first deploy (it is managed
+out-of-band, not by Terraform, so the secret value never enters Terraform
+state):
+
+```bash
+aws ssm put-parameter \
+  --name "/netzero/api_key" \
+  --type SecureString \
+  --value "<your-netzero-api-key>" \
+  --region us-east-1
+```
+
+To rotate the key later, re-run with `--overwrite`. The parameter name is
+configurable via the `api_key_param_name` Terraform variable.
 
 ### 3. Deploy
 

--- a/evening_config.py
+++ b/evening_config.py
@@ -1,8 +1,9 @@
 import json
 import os
 import time
-import requests
 import logging
+import boto3
+import requests
 from datetime import datetime
 
 logger = logging.getLogger()
@@ -12,6 +13,22 @@ logger.setLevel(logging.INFO)
 MAX_RETRIES = 3
 BACKOFF_BASE_SECONDS = 2
 REQUEST_TIMEOUT_SECONDS = 15
+
+# The NetZero API key is stored as an SSM Parameter Store SecureString and
+# fetched at runtime, so it never lives in the Lambda env config or TF state.
+API_KEY_PARAM = os.getenv("API_KEY_PARAM", "/netzero/api_key")
+_ssm_client = boto3.client("ssm")
+_api_key_cache = None
+
+
+def get_api_key():
+    """Fetch (and cache across warm invocations) the NetZero API key from the
+    SSM Parameter Store SecureString."""
+    global _api_key_cache
+    if _api_key_cache is None:
+        response = _ssm_client.get_parameter(Name=API_KEY_PARAM, WithDecryption=True)
+        _api_key_cache = response["Parameter"]["Value"]
+    return _api_key_cache
 
 
 def post_with_retry(url, config, headers):
@@ -38,17 +55,16 @@ def post_with_retry(url, config, headers):
 def lambda_handler(event, context):
     """AWS Lambda handler for evening Tesla Powerwall configuration"""
 
-    api_key = os.getenv("API_KEY")
     site_id = os.getenv("SITE_ID")
 
-    if not api_key or not site_id:
-        logger.error("API_KEY and SITE_ID environment variables are required")
+    if not site_id:
+        logger.error("SITE_ID environment variable is required")
         return {
             "statusCode": 400,
-            "body": json.dumps(
-                {"error": "Missing API_KEY or SITE_ID environment variables"}
-            ),
+            "body": json.dumps({"error": "Missing SITE_ID environment variable"}),
         }
+
+    api_key = get_api_key()
 
     url = f"https://api.netzero.energy/api/v1/{site_id}/config"
     headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}

--- a/morning_config.py
+++ b/morning_config.py
@@ -1,8 +1,9 @@
 import json
 import os
 import time
-import requests
 import logging
+import boto3
+import requests
 from datetime import datetime
 
 logger = logging.getLogger()
@@ -12,6 +13,22 @@ logger.setLevel(logging.INFO)
 MAX_RETRIES = 3
 BACKOFF_BASE_SECONDS = 2
 REQUEST_TIMEOUT_SECONDS = 15
+
+# The NetZero API key is stored as an SSM Parameter Store SecureString and
+# fetched at runtime, so it never lives in the Lambda env config or TF state.
+API_KEY_PARAM = os.getenv("API_KEY_PARAM", "/netzero/api_key")
+_ssm_client = boto3.client("ssm")
+_api_key_cache = None
+
+
+def get_api_key():
+    """Fetch (and cache across warm invocations) the NetZero API key from the
+    SSM Parameter Store SecureString."""
+    global _api_key_cache
+    if _api_key_cache is None:
+        response = _ssm_client.get_parameter(Name=API_KEY_PARAM, WithDecryption=True)
+        _api_key_cache = response["Parameter"]["Value"]
+    return _api_key_cache
 
 
 def post_with_retry(url, config, headers):
@@ -38,17 +55,16 @@ def post_with_retry(url, config, headers):
 def lambda_handler(event, context):
     """AWS Lambda handler for morning Tesla Powerwall configuration"""
 
-    api_key = os.getenv("API_KEY")
     site_id = os.getenv("SITE_ID")
 
-    if not api_key or not site_id:
-        logger.error("API_KEY and SITE_ID environment variables are required")
+    if not site_id:
+        logger.error("SITE_ID environment variable is required")
         return {
             "statusCode": 400,
-            "body": json.dumps(
-                {"error": "Missing API_KEY or SITE_ID environment variables"}
-            ),
+            "body": json.dumps({"error": "Missing SITE_ID environment variable"}),
         }
+
+    api_key = get_api_key()
 
     url = f"https://api.netzero.energy/api/v1/{site_id}/config"
     headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -210,6 +210,34 @@ resource "aws_iam_role_policy_attachment" "lambda_basic" {
   role       = aws_iam_role.lambda_role.name
 }
 
+# Allow the Lambdas to read the NetZero API key (SSM SecureString) at runtime,
+# including KMS decryption via the SSM service.
+resource "aws_iam_role_policy" "lambda_ssm_read" {
+  name = "netzero-lambda-ssm-read"
+  role = aws_iam_role.lambda_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "ssm:GetParameter"
+        Resource = "arn:aws:ssm:us-east-1:358870220937:parameter${var.api_key_param_name}"
+      },
+      {
+        Effect   = "Allow"
+        Action   = "kms:Decrypt"
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "kms:ViaService" = "ssm.us-east-1.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+}
+
 # IAM role for EventBridge Scheduler to invoke Lambda
 resource "aws_iam_role" "scheduler_role" {
   name       = "netzero-scheduler-role"

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -10,8 +10,8 @@ resource "aws_lambda_function" "morning_config" {
 
   environment {
     variables = {
-      API_KEY = var.api_key
-      SITE_ID = var.site_id
+      API_KEY_PARAM = var.api_key_param_name
+      SITE_ID       = var.site_id
     }
   }
 
@@ -30,8 +30,8 @@ resource "aws_lambda_function" "evening_config" {
 
   environment {
     variables = {
-      API_KEY = var.api_key
-      SITE_ID = var.site_id
+      API_KEY_PARAM = var.api_key_param_name
+      SITE_ID       = var.site_id
     }
   }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -4,15 +4,15 @@ variable "aws_region" {
   default     = "us-east-1"
 }
 
-variable "api_key" {
-  description = "NetZero API key"
-  type        = string
-  sensitive   = true
-}
-
 variable "site_id" {
   description = "Tesla site ID"
   type        = string
+}
+
+variable "api_key_param_name" {
+  description = "Name of the SSM Parameter Store SecureString holding the NetZero API key. The parameter is created out-of-band (not by Terraform) so the secret value never enters Terraform state."
+  type        = string
+  default     = "/netzero/api_key"
 }
 
 variable "alert_email" {


### PR DESCRIPTION
## Summary

Removes the NetZero API key from plaintext storage. It was a Lambda **environment variable** (readable via `lambda:GetFunctionConfiguration`) and lived in **Terraform state**. Now it's an **SSM Parameter Store SecureString** the Lambdas fetch at runtime.

This is PR 1 of 2 from the security review (the other is OIDC for CI auth).

## Changes
- **Lambda code**: fetch the key from SSM via `boto3` at runtime (boto3 ships in the Lambda runtime — no new dependency), cached across warm invocations. `SITE_ID` stays an env var (not a secret).
- **Out of state entirely**: the parameter is managed **out-of-band**, and Terraform references only its *name* (`api_key_param_name`), never its value — so the secret no longer enters Terraform state.
- **Least-privilege runtime access**: the Lambda role gets `ssm:GetParameter` scoped to the parameter ARN, plus `kms:Decrypt` constrained to the SSM service via a `kms:ViaService` condition.
- Removes the `api_key` Terraform variable, the `-var="api_key=…"` from the deploy plan steps, and the `API_KEY` check from CI.

## ⚠️ Required one-time step before this deploys
Create the SecureString (the deploy itself doesn't need it, but the Lambdas will fail at runtime until it exists):

```bash
aws ssm put-parameter \
  --name "/netzero/api_key" \
  --type SecureString \
  --value "<your-netzero-api-key>" \
  --region us-east-1
```

Afterward, the `API_KEY` GitHub secret is unused and can be deleted.

## Testing
- `black --check` clean; blocking `flake8` pass (E9/F63/F7/F82) = 0.
- `terraform fmt -check -recursive` clean.
- No new permissions required for the deploy user (it already has `iam:PutRolePolicy` on `netzero-*` roles and `lambda:UpdateFunctionConfiguration`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019mgbdwt9SRP15mf1QaGLcG)_