### PR TITLE
Add GitHub OIDC provider + assumable role (bootstrap, admin-applied)

### DIFF
--- a/terraform-bootstrap/oidc.tf
+++ b/terraform-bootstrap/oidc.tf
@@ -1,0 +1,140 @@
+# GitHub Actions OIDC for CI authentication
+#
+# These resources let the deploy workflow assume a short-lived IAM role via an
+# OIDC token instead of long-lived AWS access keys. They live in the bootstrap
+# config because creating an IAM identity provider requires permissions the
+# least-privilege CI user deliberately does NOT have -- so an admin applies this
+# once. It is purely additive: it does not touch the existing CI user, its
+# access keys, or the running pipeline.
+#
+# Apply (admin creds), targeting only these resources so it ignores the
+# pre-existing state bucket:
+#
+#   cd terraform-bootstrap
+#   terraform init
+#   terraform apply \
+#     -target=aws_iam_openid_connect_provider.github \
+#     -target=aws_iam_role.github_actions_oidc \
+#     -target=aws_iam_role_policy_attachment.oidc_deploy \
+#     -target=aws_iam_role_policy.oidc_control_plane
+
+# OIDC identity provider for GitHub Actions.
+resource "aws_iam_openid_connect_provider" "github" {
+  url            = "https://token.actions.githubusercontent.com"
+  client_id_list = ["sts.amazonaws.com"]
+  # AWS validates the GitHub OIDC endpoint against its own trust store and no
+  # longer enforces this thumbprint, but the argument is still required.
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}
+
+# Role the deploy workflow assumes. Trust is scoped to this repo's main branch
+# so only pushes to main (the deploy trigger) can assume it.
+resource "aws_iam_role" "github_actions_oidc" {
+  name = "netzero-github-actions-oidc"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Action    = "sts:AssumeRoleWithWebIdentity"
+        Principal = { Federated = aws_iam_openid_connect_provider.github.arn }
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = "repo:vyas0189/powerwall:ref:refs/heads/main"
+          }
+        }
+      }
+    ]
+  })
+}
+
+# Operational/data-plane permissions: reuse the same customer-managed policy the
+# CI user already has (created by the main Terraform config), referenced by ARN.
+resource "aws_iam_role_policy_attachment" "oidc_deploy" {
+  role       = aws_iam_role.github_actions_oidc.name
+  policy_arn = "arn:aws:iam::358870220937:policy/netzero-deploy"
+}
+
+# Control-plane permissions: mirrors the CI user's inline policy so the role can
+# manage IAM (roles, the user's policies, the managed policy), logs, and state.
+resource "aws_iam_role_policy" "oidc_control_plane" {
+  name = "netzero-control-plane"
+  role = aws_iam_role.github_actions_oidc.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "iam:GetRole",
+          "iam:CreateRole",
+          "iam:PassRole",
+          "iam:AttachRolePolicy",
+          "iam:DetachRolePolicy",
+          "iam:ListRolePolicies",
+          "iam:ListAttachedRolePolicies",
+          "iam:GetRolePolicy",
+          "iam:PutRolePolicy",
+          "iam:DeleteRolePolicy"
+        ]
+        Resource = "arn:aws:iam::358870220937:role/netzero-*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["iam:GetUserPolicy", "iam:PutUserPolicy", "iam:ListAttachedUserPolicies"]
+        Resource = "arn:aws:iam::358870220937:user/netzero-github-actions"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "iam:CreatePolicy",
+          "iam:DeletePolicy",
+          "iam:GetPolicy",
+          "iam:GetPolicyVersion",
+          "iam:ListPolicyVersions",
+          "iam:CreatePolicyVersion",
+          "iam:DeletePolicyVersion",
+          "iam:ListPolicyTags",
+          "iam:TagPolicy",
+          "iam:UntagPolicy"
+        ]
+        Resource = "arn:aws:iam::358870220937:policy/netzero-*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["iam:AttachUserPolicy", "iam:DetachUserPolicy"]
+        Resource = "arn:aws:iam::358870220937:user/netzero-github-actions"
+        Condition = {
+          ArnLike = {
+            "iam:PolicyARN" = "arn:aws:iam::358870220937:policy/netzero-*"
+          }
+        }
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["logs:CreateLogGroup", "logs:DescribeLogGroups"]
+        Resource = "arn:aws:logs:us-east-1:358870220937:log-group:/aws/lambda/netzero-*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+        Resource = "arn:aws:s3:::netzero-terraform-state-358870220937/terraform.tfstate"
+      },
+      {
+        Effect   = "Allow"
+        Action   = "s3:ListBucket"
+        Resource = "arn:aws:s3:::netzero-terraform-state-358870220937"
+      }
+    ]
+  })
+}
+
+output "github_actions_oidc_role_arn" {
+  description = "ARN of the role the deploy workflow should assume via OIDC."
+  value       = aws_iam_role.github_actions_oidc.arn
+}


### PR DESCRIPTION
## Summary

PR 2a of the OIDC migration (moving CI auth off long-lived AWS access keys). Adds the OIDC identity provider + an assumable IAM role to the **admin-applied** `terraform-bootstrap` config. This is the piece the least-privilege CI user can't create itself (`iam:CreateOpenIDConnectProvider`), so you apply it once with elevated creds.

**Purely additive / inert to the running system:**
- Does **not** touch the existing CI user or its access keys.
- CI and the deploy pipeline only operate on the `terraform/` dir, so this `terraform-bootstrap/` change triggers **no** workflow and **no** deploy.

## What it creates
- `aws_iam_openid_connect_provider` for `token.actions.githubusercontent.com`.
- `aws_iam_role` `netzero-github-actions-oidc`, trust **scoped to `repo:vyas0189/powerwall:ref:refs/heads/main`** (only main-branch pushes — the deploy trigger — can assume it) with `aud = sts.amazonaws.com`.
- Attaches the existing `netzero-deploy` managed policy (operational perms) + a control-plane inline policy mirroring the CI user's.

## 🛠️ Apply (admin, one-time)

Run with your **admin** AWS creds, targeting only these resources so it ignores the pre-existing state bucket:

```bash
cd terraform-bootstrap
terraform init
·t·erraform a·pply \
  -target=aws_iam_openid_connect_provider.github \
  -target=aws_iam_role.github_actions_oidc \
  -target=aws_iam_role_policy_attachment.oidc_deploy \
  -target=aws_iam_role_policy.oidc_control_plane
```

It prints `github_actions_oidc_role_arn` — that's the ARN PR 2b will plug into the workflow.

## Next (PR 2b)
After you apply this and confirm the role exists, I'll open the workflow switch: `configure-aws-credentials` → `role-to-assume`, add `id-token: write`, and **keep the access-key secrets as a fallback** until a deploy proves OIDC works. Then a final PR retires the user/keys.

## Testing
- `terraform fmt -check -recursive` clean on `terraform-bootstrap`.
- No CI impact (the `terraform/` validate/plan are unaffected; bootstrap isn't in their path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019mgbdwt9SRP15mf1QaGLcG)_