### PR TITLE
Switch deploy workflow to OIDC role (keys kept as fallback)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,10 @@ on:
 env:
   AWS_REGION: us-east-1
   TF_VERSION: 1.5.0
+  # Role assumed via GitHub OIDC (created in terraform-bootstrap). The CI user's
+  # access-key secrets are kept in the repo as a fallback: reverting the two
+  # "Configure AWS credentials" steps below to key auth restores the old path.
+  AWS_OIDC_ROLE_ARN: arn:aws:iam::358870220937:role/netzero-github-actions-oidc
 
 jobs:
   terraform-pr:
@@ -45,6 +49,7 @@ jobs:
     name: terraform
     permissions:
       contents: read
+      id-token: write
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     
@@ -64,8 +69,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        role-to-assume: ${{ env.AWS_OIDC_ROLE_ARN }}
         aws-region: ${{ env.AWS_REGION }}
     
     - name: Terraform Format Check
@@ -100,6 +104,7 @@ jobs:
     name: Apply Terraform Changes
     permissions:
       contents: read
+      id-token: write
     runs-on: ubuntu-latest
     needs: [terraform, approve]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
@@ -120,8 +125,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        role-to-assume: ${{ env.AWS_OIDC_ROLE_ARN }}
         aws-region: ${{ env.AWS_REGION }}
     
     - name: Terraform Init


### PR DESCRIPTION
## Summary

PR 2b — the second half of the OIDC migration. The deploy workflow now authenticates to AWS by **assuming the `netzero-github-actions-oidc` role via a GitHub OIDC token** instead of long-lived access keys. The bootstrap role this depends on (PR #52) is already applied in the account.

## Changes (`deploy.yml`)
- Both AWS-using jobs — `terraform` (plan) and `apply` — get `permissions: id-token: write` so the runner can mint an OIDC token. The `terraform-pr` check job is **unchanged** (it never touches AWS).
- Their `Configure AWS credentials` steps switch from `aws-access-key-id`/`aws-secret-access-key` to `role-to-assume`.
- Role ARN lives in the `AWS_OIDC_ROLE_ARN` workflow env var.

Both jobs run only on push to `main`, which matches the role's trust condition (`repo:vyas0189/powerwall:ref:refs/heads/main`, `aud=sts.amazonaws.com`).

## Safety — keys kept as a fallback
This is the additive, low-risk step you chose:
- The `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` secrets and the IAM user are **left untouched**.
- If OIDC misbehaves, reverting these two `Configure` steps to key auth fully restores the old path — **no AWS changes, no lockout risk.**

## How to verify after merge
Merging triggers a deploy. Watch the **Configure AWS credentials** step in the `terraform` job:
- ✅ It assumes the role (you'll see `Assuming role with OIDC` / no key usage) and the plan runs → OIDC works.
- ❌ If it fails (e.g. `Not authorized to perform sts:AssumeRoleWithWebIdentity`), the fix is a one-line revert of the Configure steps back to keys while we adjust the trust policy.

The plan should be a **no-op** (no `terraform/` resource changes), so this only exercises the auth path.

## Follow-up (PR 2c, after this is proven)
Once a deploy succeeds via OIDC, retire the IAM user + access keys and delete the now-unused secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019mgbdwt9SRP15mf1QaGLcG)_