### PR TITLE
Retire the long-lived CI IAM user (OIDC migration cleanup)

### DIFF
--- a/terraform/alerts.tf
+++ b/terraform/alerts.tf
@@ -1,17 +1,17 @@
-# Give IAM time to propagate the deploy user's operational grants before any
-# resource that needs them is created. The operational permissions now come from
-# the attached customer-managed policy (aws_iam_policy.deploy), so wait on the
-# attachment. Without this, a fresh apply can fire CreateTopic/CreateQueue within
-# ~1s of the grant and get a 403 (IAM is eventually consistent).
+# Give IAM time to propagate changes to the deploy role's operational grants
+# before any resource that needs them is created. Those permissions come from the
+# customer-managed policy (aws_iam_policy.deploy), attached to the OIDC deploy
+# role in terraform-bootstrap. Without this, a fresh apply can fire
+# CreateTopic/CreateQueue within ~1s of a grant change and get a 403 (IAM is
+# eventually consistent).
 resource "time_sleep" "wait_for_iam_propagation" {
-  depends_on      = [aws_iam_user_policy_attachment.deploy]
+  depends_on      = [aws_iam_policy.deploy]
   create_duration = "30s"
 
-  # Re-wait whenever the managed policy document or attachment changes, so future
-  # permission additions get the same propagation grace period.
+  # Re-wait whenever the managed policy document changes, so future permission
+  # additions get the same propagation grace period.
   triggers = {
-    policy     = aws_iam_policy.deploy.policy
-    attachment = aws_iam_user_policy_attachment.deploy.id
+    policy = aws_iam_policy.deploy.policy
   }
 }
 

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,91 +1,11 @@
-# Inline policy for the GitHub Actions deploy user — CONTROL PLANE only.
+# Customer-managed policy: the operational/data-plane permissions for deploys,
+# explicit and scoped to netzero-* resources. The 6144-byte limit leaves room to
+# spell out least-privilege actions instead of service wildcards.
 #
-# The operational/data-plane permissions (Lambda, Scheduler, SNS, SQS,
-# CloudWatch, Logs) live in the customer-managed policy below, which has a
-# 6144-byte limit and so can spell out explicit, least-privilege actions
-# instead of the service wildcards an inline policy was forced to use (the
-# aggregate inline-policy budget for a user is only 2048 bytes).
-#
-# This inline policy intentionally retains the permissions needed to manage and
-# attach that managed policy, plus self-policy management, so the deploy user
-# can always recover from a half-applied change (it can never lock itself out).
-resource "aws_iam_user_policy" "github_actions_policy" {
-  name = "GitHubActionsPolicy"
-  user = "netzero-github-actions"
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "iam:GetRole",
-          "iam:CreateRole",
-          "iam:PassRole",
-          "iam:AttachRolePolicy",
-          "iam:DetachRolePolicy",
-          "iam:ListRolePolicies",
-          "iam:ListAttachedRolePolicies",
-          "iam:GetRolePolicy",
-          "iam:PutRolePolicy",
-          "iam:DeleteRolePolicy"
-        ]
-        Resource = "arn:aws:iam::358870220937:role/netzero-*"
-      },
-      {
-        Effect   = "Allow"
-        Action   = ["iam:GetUserPolicy", "iam:PutUserPolicy", "iam:ListAttachedUserPolicies"]
-        Resource = "arn:aws:iam::358870220937:user/netzero-github-actions"
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "iam:CreatePolicy",
-          "iam:DeletePolicy",
-          "iam:GetPolicy",
-          "iam:GetPolicyVersion",
-          "iam:ListPolicyVersions",
-          "iam:CreatePolicyVersion",
-          "iam:DeletePolicyVersion",
-          "iam:ListPolicyTags",
-          "iam:TagPolicy",
-          "iam:UntagPolicy"
-        ]
-        Resource = "arn:aws:iam::358870220937:policy/netzero-*"
-      },
-      {
-        # Limit attach/detach to netzero-* managed policies so the deploy user
-        # cannot escalate by attaching, e.g., AdministratorAccess to itself.
-        Effect   = "Allow"
-        Action   = ["iam:AttachUserPolicy", "iam:DetachUserPolicy"]
-        Resource = "arn:aws:iam::358870220937:user/netzero-github-actions"
-        Condition = {
-          ArnLike = {
-            "iam:PolicyARN" = "arn:aws:iam::358870220937:policy/netzero-*"
-          }
-        }
-      },
-      {
-        Effect   = "Allow"
-        Action   = ["logs:CreateLogGroup", "logs:DescribeLogGroups"]
-        Resource = "arn:aws:logs:us-east-1:358870220937:log-group:/aws/lambda/netzero-*"
-      },
-      {
-        Effect   = "Allow"
-        Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
-        Resource = "arn:aws:s3:::netzero-terraform-state-358870220937/terraform.tfstate"
-      },
-      {
-        Effect   = "Allow"
-        Action   = "s3:ListBucket"
-        Resource = "arn:aws:s3:::netzero-terraform-state-358870220937"
-      }
-    ]
-  })
-}
-
-# Customer-managed policy: the operational/data-plane permissions, explicit and
-# scoped to netzero-* resources. 6144-byte limit leaves room to avoid wildcards.
+# This policy is consumed by the GitHub Actions deploy role
+# (netzero-github-actions-oidc), which the deploy workflow assumes via OIDC; the
+# attachment to that role lives in terraform-bootstrap. The former long-lived
+# IAM user (netzero-github-actions) and its access keys have been retired.
 resource "aws_iam_policy" "deploy" {
   name        = "netzero-deploy"
   description = "Operational deploy permissions for netzero infrastructure (Lambda, Scheduler, SNS, SQS, CloudWatch, Logs)."
@@ -165,24 +85,6 @@ resource "aws_iam_policy" "deploy" {
   })
 }
 
-# Wait for the inline policy's control-plane grants (CreatePolicy /
-# AttachUserPolicy) to propagate before creating/attaching the managed policy.
-resource "time_sleep" "wait_for_iam_control_plane" {
-  depends_on      = [aws_iam_user_policy.github_actions_policy]
-  create_duration = "30s"
-
-  triggers = {
-    policy = aws_iam_user_policy.github_actions_policy.policy
-  }
-}
-
-resource "aws_iam_user_policy_attachment" "deploy" {
-  user       = "netzero-github-actions"
-  policy_arn = aws_iam_policy.deploy.arn
-
-  depends_on = [time_sleep.wait_for_iam_control_plane]
-}
-
 # IAM role for Lambda functions
 resource "aws_iam_role" "lambda_role" {
   name = "netzero-lambda-role"
@@ -240,8 +142,7 @@ resource "aws_iam_role_policy" "lambda_ssm_read" {
 
 # IAM role for EventBridge Scheduler to invoke Lambda
 resource "aws_iam_role" "scheduler_role" {
-  name       = "netzero-scheduler-role"
-  depends_on = [aws_iam_user_policy.github_actions_policy]
+  name = "netzero-scheduler-role"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"


### PR DESCRIPTION
## Summary

Final step of the OIDC migration. Deploys now authenticate via the `netzero-github-actions-oidc` role (proven green in the #53 deploy), so the long-lived `netzero-github-actions` IAM user and its access keys are obsolete. This removes the Terraform that managed that user.

**Removed (`iam.tf`):**
- `aws_iam_user_policy.github_actions_policy` — the inline control-plane policy
- `aws_iam_user_policy_attachment.deploy` — managed-policy attachment to the user
- `time_sleep.wait_for_iam_control_plane` — its propagation guard
- the `scheduler_role` `depends_on` that referenced the inline user policy

**Kept:** `aws_iam_policy.deploy` (the customer-managed operational policy) — it's now attached to the OIDC role in `terraform-bootstrap`. `alerts.tf`'s `wait_for_iam_propagation` is re-pointed from the removed user attachment to the managed policy, so it still gives a 30s grace period when the policy changes.

## ⚠️ Important: this needs an ordered teardown, not a plain merge

The IAM **user** was created out-of-band (never a Terraform resource), and the OIDC role **intentionally lacks `iam:DeleteUserPolicy`** — so if you just merge, the pipeline will try to destroy the inline user policy and fail. Do it in this order instead (admin creds, locally):

**1. Drop the user-tied resources from remote state** (so neither this branch's config nor state reference them):
```bash
git fetch origin && git checkout claude/netzero-api-alerts-retry-2dpgt8
cd terraform && terraform init
terraform state rm \
  aws_iam_user_policy.github_actions_policy \
  aws_iam_user_policy_attachment.deploy \
  time_sleep.wait_for_iam_control_plane
```

**2. Sanity-check** — `terraform plan` should show only the `wait_for_iam_propagation` timer being replaced, and **no** IAM-user destroys.

**3. Delete the IAM user + access keys** (console "Delete user" cascades all of this, or by CLI):
```bash
aws iam list-access-keys --user-name netzero-github-actions
aws iam delete-access-key  --user-name netzero-github-actions --access-key-id <AKIA...>
aws iam delete-user-policy --user-name netzero-github-actions --policy-name GitHubActionsPolicy
aws iam detach-user-policy --user-name netzero-github-actions --policy-arn arn:aws:iam::358870220937:policy/netzero-deploy
aws iam delete-user        --user-name netzero-github-actions
```

**4. Merge this PR.** The deploy runs as the OIDC role against clean config + state → green (just the 30s propagation timer re-creates).

**5. Delete the now-unused secrets:**
```bash
gh secret delete AWS_ACCESS_KEY_ID     --repo vyas0189/powerwall
gh secret delete AWS_SECRET_ACCESS_KEY --repo vyas0189/powerwall
```

> Do steps 1–4 in one sitting and **don't push to `main` in between** — between the state-rm and the merge, `main` still carries the old config, so a deploy in that window could try to recreate the resources.

## Lighter alternative
If you'd rather not do the state dance: the real security win is just **deleting the access keys + the two secrets** (steps 3's key-deletion + step 5). That leaves an inert, keyless user and needs no Terraform change — you could close this PR and skip it. This PR is the full cleanup (no lingering user).

## Testing
- `terraform fmt -check -recursive` clean.
- No dangling references to the removed resources anywhere in `terraform/`.
- `validate` runs in the `terraform-pr` CI check (no AWS needed).

## Optional follow-up
The OIDC role's control-plane policy in `terraform-bootstrap` still has statements scoped to the deleted user ARN — harmless (they reference a non-existent principal), but can be trimmed later for tidiness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019mgbdwt9SRP15mf1QaGLcG)_