### PR TITLE
Fix deploy failures from #55 (state-lock perm + drop default_tags)

### DIFF
--- a/terraform-bootstrap/oidc.tf
+++ b/terraform-bootstrap/oidc.tf
@@ -108,9 +108,12 @@ resource "aws_iam_role_policy" "oidc_control_plane" {
         Resource = "arn:aws:logs:us-east-1:358870220937:log-group:/aws/lambda/netzero-*"
       },
       {
-        Effect   = "Allow"
-        Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
-        Resource = "arn:aws:s3:::netzero-terraform-state-358870220937/terraform.tfstate"
+        Effect = "Allow"
+        Action = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+        # Covers the state object plus the native S3 lock file
+        # (terraform.tfstate.tflock, written when use_lockfile = true) and
+        # state backups.
+        Resource = "arn:aws:s3:::netzero-terraform-state-358870220937/terraform.tfstate*"
       },
       {
         Effect   = "Allow"


### PR DESCRIPTION
The post-merge deploy of #55 surfaced two issues. Both fixed here.

## 1. State lock permission (AccessDenied on `terraform.tfstate.tflock`)
`use_lockfile = true` writes a lock object at `terraform.tfstate.tflock`, but the OIDC deploy role's S3 grant was scoped to the exact `terraform.tfstate` key. Broadened to `terraform.tfstate*` in `terraform-bootstrap/oidc.tf`. **Already applied to AWS** via targeted bootstrap apply (admin-applied; not in the pipeline) — this keeps the repo in sync.

## 2. `default_tags` broke the apply (AccessDenied on `iam:TagRole` / `logs:TagResource`)
`default_tags` tags every resource, needing tagging permissions the least-privilege deploy role lacks — `iam:TagRole` on the lambda/scheduler roles (granted nowhere) and `logs:TagResource` at log-group creation. Granting those broadly for cosmetic tags would undercut the least-privilege posture, so `default_tags` is removed. The state bucket remains tagged via bootstrap.

### Already applied in the partial run (verified)
- ✅ SQS DLQ SSE (`SqsManagedSseEnabled=true`)
- ✅ SNS KMS (`alias/aws/sns`)
- ✅ DLQ-depth alarm created

### Remaining after merge
The deploy re-applies and creates the two CloudWatch log groups (30-day retention), now untagged — the deploy role already has the needed logs permissions (verified live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)