### PR TITLE
Actually remove default_tags (the removal missed the #56 merge)

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -21,12 +21,4 @@ terraform {
 
 provider "aws" {
   region = var.aws_region
-
-  default_tags {
-    tags = {
-      Project     = "netzero-scheduler"
-      Environment = "production"
-      ManagedBy   = "terraform"
-    }
-  }
 }


### PR DESCRIPTION
## Why

The post-#55 deploy keeps failing at apply with `AccessDenied: iam:TagRole` (and `logs:TagResource` at log-group creation). Root cause: `provider.default_tags` tags every resource, needing tagging permissions the least-privilege deploy role lacks.

The fix for this was committed to the #56 branch **after** #56 had already merged (#56 merged at `88b3e20`, which only carried the S3 state-lock permission). So `main` still has `default_tags` and the apply still fails. This PR actually lands the removal on `main`.

## What

Remove `provider.default_tags`. Cosmetic tags aren't worth granting broad IAM/Lambda/Logs tagging permissions to the deploy role (it would undercut the least-privilege posture #55 tightened). The state bucket stays tagged via bootstrap.

After merge, the deploy creates the two CloudWatch log groups (30-day retention) untagged — the roles currently have no tags and the logs permissions are already live. SQS SSE, SNS KMS, and the DLQ alarm already applied in the earlier partial run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)