### PR TITLE
Import existing Lambda log groups (fix ResourceAlreadyExists)

### DIFF
--- a/terraform/imports.tf
+++ b/terraform/imports.tf
@@ -1,0 +1,17 @@
+# The Lambda runtime auto-creates each function's log group on first invocation
+# (with infinite retention), so Terraform's plain "create" conflicts with the
+# already-existing group. These import blocks bring the existing groups into
+# state so Terraform manages their retention (30 days) instead of trying to
+# create them.
+#
+# Safe to leave in place: once a group is in state the import is a no-op, and it
+# self-heals the state if a group is ever deleted out of band.
+import {
+  to = aws_cloudwatch_log_group.morning_config
+  id = "/aws/lambda/netzero-morning-config"
+}
+
+import {
+  to = aws_cloudwatch_log_group.evening_config
+  id = "/aws/lambda/netzero-evening-config"
+}


### PR DESCRIPTION
## Why

The deploy failed at apply with:

```
ResourceAlreadyExistsException: The specified log group already exists
  aws_cloudwatch_log_group.morning_config / .evening_config
```

The Lambda runtime auto-creates `/aws/lambda/netzero-{morning,evening}-config` on first invocation (with infinite retention), so Terraform's plain create conflicts with the existing groups.

## What

Add Terraform `import` blocks so the pipeline imports the existing groups into state and then manages their 30-day retention — instead of trying to create them. Fully pipeline-native: the import runs in the pipeline's `plan`/`apply` (TF 1.10.5, S3 backend) using the deploy role's `logs:DescribeLogGroups` + `logs:PutRetentionPolicy`, which are already live. No out-of-band state changes.

Left in place intentionally (idempotent once imported; self-heals if a group is ever deleted out of band).

## After merge
The apply imports both groups and sets `retention_in_days = 30`. This is the last remaining piece — SQS SSE, SNS KMS, and the DLQ alarm already applied in earlier runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)