### PR TITLE
Grant deploy role logs:DescribeLogGroups on * (unblock log-group import)

### DIFF
--- a/terraform-bootstrap/oidc.tf
+++ b/terraform-bootstrap/oidc.tf
@@ -104,8 +104,16 @@ resource "aws_iam_role_policy" "oidc_control_plane" {
       },
       {
         Effect   = "Allow"
-        Action   = ["logs:CreateLogGroup", "logs:DescribeLogGroups"]
+        Action   = "logs:CreateLogGroup"
         Resource = "arn:aws:logs:us-east-1:358870220937:log-group:/aws/lambda/netzero-*"
+      },
+      {
+        # DescribeLogGroups is a list action that does not support resource-level
+        # scoping (AWS evaluates it against all log groups), so it must be on "*".
+        # Needed so the deploy role can import the Lambda-created log groups.
+        Effect   = "Allow"
+        Action   = "logs:DescribeLogGroups"
+        Resource = "*"
       },
       {
         Effect = "Allow"

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -84,7 +84,6 @@ resource "aws_iam_policy" "deploy" {
         Action = [
           "logs:CreateLogGroup",
           "logs:DeleteLogGroup",
-          "logs:DescribeLogGroups",
           "logs:PutRetentionPolicy",
           "logs:DeleteRetentionPolicy",
           "logs:ListTagsForResource",
@@ -92,6 +91,12 @@ resource "aws_iam_policy" "deploy" {
           "logs:UntagResource"
         ]
         Resource = "arn:aws:logs:us-east-1:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/netzero-*"
+      },
+      {
+        # DescribeLogGroups is a list action with no resource-level scoping.
+        Effect   = "Allow"
+        Action   = "logs:DescribeLogGroups"
+        Resource = "*"
       }
     ]
   })


### PR DESCRIPTION
## Why

The log-group import (#58) failed at plan:

```
AccessDeniedException: not authorized to perform: logs:DescribeLogGroups
  on resource: arn:aws:logs:...:log-group::log-stream:
```

`logs:DescribeLogGroups` is a **list** action — AWS evaluates it against all log groups, so it can't be scoped to the `/aws/lambda/netzero-*` ARN. The deploy role granted it only on the prefixed ARN, so the import's read was denied. (Classic chicken-and-egg: the pipeline can't grant itself the permission it needs in order to plan.)

## What

Split `logs:DescribeLogGroups` into its own statement on `Resource = "*"`, in both:
- the admin-applied control-plane policy (`terraform-bootstrap/oidc.tf`) — **already applied to AWS** via targeted bootstrap apply, which unblocks the pipeline now;
- the managed deploy policy (`terraform/iam.tf`) — for IaC consistency.

`CreateLogGroup` / `PutRetentionPolicy` / tagging stay scoped to `netzero-*`.

## After merge
The deploy plan imports both log groups and the apply sets 30-day retention — the final remaining piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)