### PR TITLE
Build Lambda zips in the apply job (fix missing-zip apply failure)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -149,6 +149,24 @@ jobs:
         name: tfplan
         path: terraform
 
+    # Build the Lambda deployment packages on this runner. The Terraform config
+    # also builds them via a null_resource provisioner, but that only re-runs
+    # when its source hashes change; a function-code update applied from a saved
+    # plan can otherwise reference a .zip that was never built on this fresh
+    # runner. Building here guarantees the artifacts exist before apply.
+    - name: Build Lambda packages
+      working-directory: ${{ github.workspace }}
+      run: |
+        for fn in morning evening; do
+          rm -rf "temp_$fn"
+          mkdir -p "temp_$fn"
+          cp "${fn}_config.py" netzero_client.py requirements.txt "temp_$fn/"
+          python3 -m pip install --quiet -r requirements.txt -t "temp_$fn"
+          (cd "temp_$fn" && zip -rq "$GITHUB_WORKSPACE/terraform/${fn}_config.zip" .)
+          rm -rf "temp_$fn"
+        done
+        ls -l terraform/morning_config.zip terraform/evening_config.zip
+
     - name: Terraform Apply
       run: terraform apply -auto-approve tfplan
 


### PR DESCRIPTION
## Why

After the log groups imported and retention applied successfully, the apply failed at the **Lambda function update**:

```
Error: reading ZIP file (morning_config.zip): no such file or directory
Error: reading ZIP file (evening_config.zip): no such file or directory
```

The zips are built by a `null_resource` `local-exec` provisioner, which only re-runs when its source hashes change. An earlier partial apply already advanced that trigger in state, so the provisioner is skipped — but the Phase 6 code dedup left a pending Lambda code update, which tries to upload a zip that was never built on the fresh apply runner.

## What

Add a **Build Lambda packages** step in the `apply` job (before `terraform apply`) that builds `morning_config.zip` / `evening_config.zip`, so the artifacts always exist regardless of the provisioner's trigger state. `requests` is pure-Python, so the runner's Python build is fine for the Lambda 3.12 runtime.

## Status
- ✅ Log groups imported + `retention_in_days = 30` (verified live)
- ✅ SQS SSE, SNS KMS, DLQ alarm (applied earlier)
- ⬜ Lambda code update (the dedup) — lands with this fix; functions currently run the old, equivalent code, so nothing is broken meanwhile

🤖 Generated with [Claude Code](https://claude.com/claude-code)