### PR TITLE
Fix broken alert delivery: unencrypt SNS topic (CloudWatch can't publish to aws/sns key)

### DIFF
--- a/terraform/alerts.tf
+++ b/terraform/alerts.tf
@@ -19,8 +19,14 @@ resource "time_sleep" "wait_for_iam_propagation" {
 resource "aws_sns_topic" "alerts" {
   name = "netzero-alerts"
 
-  # Encrypt messages at rest with the AWS-managed SNS KMS key (no extra cost).
-  kms_master_key_id = "alias/aws/sns"
+  # NOTE: Do NOT set kms_master_key_id = "alias/aws/sns" here. The AWS-managed
+  # SNS key has a fixed key policy that does not grant the CloudWatch service
+  # principal (cloudwatch.amazonaws.com) kms:GenerateDataKey*/kms:Decrypt, so
+  # CloudWatch alarms silently fail to publish ("Failed to execute action") and
+  # no alert email is sent. This topic carries only alarm metadata (no secrets),
+  # so it is intentionally left unencrypted. If encryption at rest is required,
+  # use a customer-managed KMS key whose policy grants cloudwatch.amazonaws.com
+  # (and events.amazonaws.com) those actions.
 
   # Wait for the deploy user's SNS permissions to propagate before creating
   depends_on = [time_sleep.wait_for_iam_propagation]


### PR DESCRIPTION
## Why alerts stopped arriving

The `netzero-alerts` SNS topic was encrypted with the **AWS-managed** KMS key (`kms_master_key_id = "alias/aws/sns"`, added during recent hardening). CloudWatch alarms can only publish to an encrypted topic if the KMS key policy grants `cloudwatch.amazonaws.com` the `kms:GenerateDataKey*`/`kms:Decrypt` actions. The AWS-managed `alias/aws/sns` key has a **fixed policy that can't be edited** and doesn't grant this — so every alarm publish failed and no email was ever sent.

### Evidence (last 30 days, verified in the account)
- `netzero-evening-config` errored **3× on 2026-07-05**, `netzero-morning-config` **3× on 2026-07-11** (run + 2 EventBridge retries).
- Both alarms transitioned **OK → ALARM** at those times.
- Both alarm actions recorded **`Failed to execute action …:netzero-alerts`**.
- Topic `NumberOfMessagesPublished` metric is **empty** — nothing ever entered the topic.
- The **2026-06-22** test action (before the key was added) shows **`Successfully executed`**.
- Email subscription is confirmed and healthy (`PendingConfirmation: false`) — it was never the problem.

> The DLQ safety-net alarm points at the same topic, so it was silently broken too.

## Fix

Remove `kms_master_key_id` from the topic. The topic carries only alarm metadata (function name / state / timestamp), no secrets, so it's intentionally left unencrypted. A `NOTE` comment is added to prevent regression. If encryption at rest is ever required, use a **customer-managed** KMS key whose policy grants `cloudwatch.amazonaws.com` (and `events.amazonaws.com`) those KMS actions (~\$1/mo).

## After merge / apply
Alarm → SNS → email will work again. Recommend a one-time end-to-end test (temporarily set an alarm to ALARM, or invoke a Lambda with a forced failure) to confirm the email lands.